### PR TITLE
Treat IE10 Mobile (Windows Phone 8) as mobile browser, too

### DIFF
--- a/concord.js
+++ b/concord.js
@@ -21,7 +21,7 @@ if (!Array.prototype.indexOf) {
 	}
 var concord = {
 	version: "2.48",
-	mobile: /Android|webOS|iPhone|iPad|iPod|BlackBerry/i.test(navigator.userAgent),
+	mobile: /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile/i.test(navigator.userAgent),
 	ready: false,
 	handleEvents: true,
 	resumeCallbacks: [],


### PR DESCRIPTION
See http://blogs.windows.com/windows_phone/b/wpdev/archive/2012/10/17/getting-websites-ready-for-internet-explorer-10-on-windows-phone-8.aspx for details
