### PR TITLE
Fixed text selection in Chrome

### DIFF
--- a/concord.js
+++ b/concord.js
@@ -1213,7 +1213,6 @@ function ConcordEvents(root, editor, op, concordInstance) {
 			return;
 			}
 		if(!editor.editable($(event.target))) {
-			event.preventDefault();
 			if(root.data("mousedown") && !root.data("dragging")) {
 				var target = $(event.target);
 				if(target.hasClass("node-icon")){


### PR DESCRIPTION
Click-and-drag to select text in Chrome is not working because preventDefault is being called on the mouse move event. Although Chrome's behaviour here is inconsistent with other browsers, the fix should be harmless because according to [the spec](http://www.w3.org/TR/DOM-Level-3-Events/#event-type-mousemove), the mouse move event does not have any default action anyway.

More info: https://code.google.com/p/chromium/issues/detail?id=346473
