### PR TITLE
capture page up/down so it doesn't clobber node text

### DIFF
--- a/concord.js
+++ b/concord.js
@@ -2760,6 +2760,14 @@ function Op(opmltext){
 			var keyCaptured = false;
 			var commandKey = event.metaKey || event.ctrlKey;
 			switch(event.which) {
+                		case 33:
+					//Page up
+	                		keyCaptured = true;
+                    			break;
+                		case 34:
+					//Page down
+                    			keyCaptured = true;
+                    			break;
 				case 8:
 					//Backspace
 					if(concord.mobile){


### PR DESCRIPTION
This fixes issue #9 where the "page up" and "page down" keys delete the line text of a node if the bar cursor is on that node when the key is pressed.

The bug was reported on the smallpicture-user list here:  https://groups.google.com/forum/#!topic/smallpicture-user/kSC0fOKLh-0

